### PR TITLE
ng-model without masks and sets masks when input has values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ jspm_packages
 .idea
 lib
 build
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `ng2-input-mask` will be documented in this file
 
+## 0.0.8 - 2017-01-15
+- Fixes masks that weren't set when the input already has a value set.
+- Modify masks to return to ng-model values without the mask. If the mask is wanted in the model value, you can use '[keepMask]="true"'
+
 ## 0.0.7 - 2017-01-15
 
 - Change name masks:

--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ Example:
 
 	<input [mask]="'(000) 900-0000'" type="text" formControlName="myControl">
 
+The masks will only be set on view. If You want to keep them on the model value, you must use the option `[keepMask]="true"`
+Example:
+```html
+    <input [mask]="'(000) 900-0000'" [keepMask]="true" type="text" formControlName="myControl">
+```
+
 ## Changelog
 
 Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.


### PR DESCRIPTION
I'm using your plugin in one of my projects, and I had two problems:
  * The mask wasn't being set when I enter the view with values in the input. It was only updated when I changed the values again.
  * The model was aways keeping the masks chars. 

In this fork, I managed this two issues of mine. I'm proposing this
  * For the first case, I changed the way this plugin initializes the mask. So, when the input already has a value, the plugin will update it on initing.
  * I've also changed the plugin to, by default, keep the value model without masks. If the user wants to keep the mask, it's required to use the new input value `keepMask`.

As you can see, this two changes are problems that I faced. It's possible that its not even a problem for the rest of the world. Feel free to use it 😃